### PR TITLE
Rust support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 package-lock.json
 .venv
 .vscode
+target/
+*.rs.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
   - 1.9
 rvm:
   - 2.4
+rust:
+ - stable
 script: ./build.sh
 notifications:
   email: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "advent-of-code"
+version = "0.1.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "advent-of-code"
+version = "0.1.0"
+authors = ["Rémi Garde <remi.garde@free.fr>"]
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ optional arguments:
                         Ignore submissions from specific authors
   -l LANGUAGES, --languages LANGUAGES
                         Run submissions written in specific languages, ex:
-                        js,py, supported: c cpp go js py rb
+                        js,py, supported: c cpp go js py rb rs
   -f, --force           Force running submissions even if tool is missing
   -r, --restricted      Restrict each author to their input only
   -s, --silent          Disable debug mode
@@ -42,12 +42,12 @@ optional arguments:
 
 ## How to contribute
 
-For now we support `c`, `c++`, `javascript`, `go`, `python 3` and `ruby`.
+For now we support `c`, `c++`, `javascript`, `go`, `python 3`, `ruby`, and `rust (stable)`.
 
 You can use `create.py` tool to create a new empty submission:
 
 ```
-usage: create.py [-h] [-p {1,2}] [-l {c,cpp,go,js,py,rb}] author day
+usage: create.py [-h] [-p {1,2}] [-l {c,cpp,go,js,py,rb,rs}] author day
 
 Creates new empty submission
 
@@ -59,7 +59,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -p {1,2}, --part {1,2}
                         Create submission for one day part only
-  -l {c,cpp,go,js,py,rb}, --language {c,cpp,go,js,py,rb}
+  -l {c,cpp,go,js,py,rb,rs}, --language {c,cpp,go,js,py,rb,rs}
                         Use specified language
 ```
 

--- a/create.py
+++ b/create.py
@@ -31,11 +31,17 @@ def create_submission(author, path, language):
 		submission_content = open(os.path.join("templates", "template.py")).read().format(class_name=class_name)
 	else:
 		submission_content = open(os.path.join("templates", "template."+language)).read()
-
+	# Create an entry in Cargo.toml if its a Rust Project
 	if os.path.exists(submission_file):
 		raise FileNotEmptyException("{} not empty".format(submission_file))
 	with open(submission_file, 'w') as f:
 		f.write(submission_content)
+	if language == "rs":
+		submission_path = path + "/" + author + "." + language
+		submission_name = path[2:].replace('/','-') + "-" + author
+		cargo = open(os.path.join("Cargo.toml"),"a")
+		cargo.write('\n[[bin]]\nname = "'+submission_name+'"\npath = "'+submission_path+'"\n')
+		print("Added submission to Cargo.toml")
 	print("created "+submission_file)
 
 def create_input(author, path):
@@ -51,7 +57,7 @@ def main():
 	parser.add_argument('author', type=str, help='Name of author (github login)')
 	parser.add_argument('day', type=int, help='Day of problem (between 1 and 25)')
 	parser.add_argument('-p', '--part', type=int, help='Create submission for one day part only', choices=[1, 2])
-	parser.add_argument('-l', '--language', help='Use specified language', default="py", choices=["c", "cpp", "go", "js", "py", "rb"])
+	parser.add_argument('-l', '--language', help='Use specified language', default="py", choices=["c", "cpp", "go", "js", "py", "rb", "rs"])
 	args = parser.parse_args()
 
 	author = args.author.lower()

--- a/run.py
+++ b/run.py
@@ -13,6 +13,7 @@ from runners.go import SubmissionGo
 from runners.js import SubmissionJs
 from runners.python import Submission
 from runners.ruby import SubmissionRb
+from runners.rust import SubmissionRs
 from submission import Submission as SubmissionOld
 from runners.wrapper import SubmissionWrapper
 # utils
@@ -41,7 +42,7 @@ class bcolors:
 
 DAY_PATH_PATTERN  = 'day-[0-9]*'
 CONTEST_PATH_PATTERN = 'part-[0-9]*'
-ALLOWED_EXT = ['.c', '.cpp', '.go', '.js', '.py', '.rb']
+ALLOWED_EXT = ['.c', '.cpp', '.go', '.js', '.py', '.rb', '.rs']
 SUPPORTED_LANGUAGES = [ ext[1:] for ext in ALLOWED_EXT if is_tool(tool_for_lang(ext[1:])) ]
 
 class DifferentAnswersException(Exception):
@@ -97,6 +98,8 @@ def _load_submission(contest_path, submission, ext='.py'):
         return SubmissionJs(submission_path)
     elif ext == '.rb' and (forced_mode or is_tool('ruby')):
         return SubmissionRb(submission_path)
+    elif ext == '.rs' and (forced_mode or is_tool('cargo')):
+        return SubmissionRs(submission_path)
     return None
 
 def load_submissions_for_contest(contest_path):

--- a/runners/rust.py
+++ b/runners/rust.py
@@ -1,0 +1,40 @@
+import subprocess, os, stat
+from .wrapper import SubmissionWrapper
+import tempfile
+
+
+class CompilationError(Exception): pass
+class RuntimeError(Exception): pass
+
+class SubmissionRs(SubmissionWrapper):
+
+	def __init__(self, file):
+		DEVNULL = open(os.devnull, 'wb')
+		SubmissionWrapper.__init__(self)
+		tmpdir = tempfile.TemporaryDirectory(prefix="aoc")
+		tmpdir.cleanup()
+		try:
+			subprocess.check_output(
+				["cargo", "test", "--bin", file.replace('/', '-')[:-3]], stderr=DEVNULL).decode()
+		except subprocess.CalledProcessError as e:
+			print(e.output)
+
+		e = subprocess.Popen(["cargo", "build", "--release", "--bin", file.replace(
+                    '/', '-')[:-3]], env={**os.environ, "CARGO_TARGET_DIR": tmpdir.name}, stdout=DEVNULL, stderr=DEVNULL).wait()
+		if e > 0:
+			raise CompilationError("Could not compile "+file)
+		self.executable = tmpdir.name + "/release/" + file.replace('/', '-')[:-3]
+
+	def language(self):
+		return 'rs'
+
+	def exec(self, input):
+		try:
+			return subprocess.check_output([self.executable, input]).decode()
+		except OSError as e:
+			if e.errno == os.errno.ENOENT:
+				# executable not found
+				raise CompilationError(e)
+			else:
+				# subprocess exited with another error
+				raise RuntimeError(e)

--- a/templates/template.rs
+++ b/templates/template.rs
@@ -1,0 +1,20 @@
+use std::env::args;
+
+fn main() {
+	println!("{}", run(args().nth(1).expect("Please provide an input")))
+}
+
+fn run(input: String) -> String {
+	// Your code goes here
+	input
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_test() {
+        assert_eq!(run("Test example".to_string()), "Test example".to_string())
+    }
+}

--- a/utils.py
+++ b/utils.py
@@ -16,4 +16,6 @@ def tool_for_lang(lang):
         return 'python'
     elif lang == 'rb':
         return 'ruby'
+    elif lang == 'rs':
+        return 'cargo'
     return lang


### PR DESCRIPTION
Allows Rust to take over the world.

The rust template is fully working.
Using `create.py -l rs` will add a corresponding entry to Cargo.toml
Running the submission will firstly run the unitary tests, then compile (in release mode)

I chose `cargo` over `rustc` to be able to resolve dependencies easily. However cargo is pretty stubborn for the paths used so it needs entries in Cargo.toml, and an environment variable during the compilation to target a custom directory.

Its been a while since I've used `subprocess` so there might be a better way to compile.

I will add a real submission tomorrow.

Want to try Rust ? `curl https://sh.rustup.rs -sSf | sh`